### PR TITLE
fix: update 'feeph/i2c/__init__.py' with correct import

### DIFF
--- a/src/feeph/i2c/__init__.py
+++ b/src/feeph/i2c/__init__.py
@@ -4,5 +4,5 @@
 
 # the following imports are provided for user convenience
 # flake8: noqa: F401
-from feeph.i2c.bus import I2cBus, SimulatedI2cBus
+from feeph.i2c.bus import HardwareI2cBus, SimulatedI2cBus
 from feeph.i2c.device import I2cDevice

--- a/tests/test_simulated_i2cbus.py
+++ b/tests/test_simulated_i2cbus.py
@@ -5,7 +5,7 @@ perform I²C bus related tests
 
 import unittest
 
-import feeph.i2c.bus as sut  # sytem under test
+import feeph.i2c as sut  # sytem under test
 
 
 class TestSimulatedI2cBus(unittest.TestCase):


### PR DESCRIPTION
The class "I2cBus" was renamed in a previous change. Update __init__.py to reflect this change.