### PR TITLE
build: ensure package upload is performed exactly once

### DIFF
--- a/.github/workflows/build-and-upload.yaml
+++ b/.github/workflows/build-and-upload.yaml
@@ -3,6 +3,7 @@ name: publish on TestPyPI
 
 on:
   release:
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
When creating a release the following 3 event types are triggered:
 - 'create'
 - 'released' or 'prereleased'
 - 'publish'

Trying to upload multiple packages with the same version will lead to an error. To ensure the package is uploaded exactly once we will trigger on 'publish'.

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release for details.