### PR TITLE
ci: split testing and coverage report into separate actions

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -1,0 +1,38 @@
+---
+#
+# https://coveralls.io/
+#
+
+name: update coverage report (coveralls)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  coverage:
+    name: generate coverage report
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+      - name: configure Python (using PDM)
+        uses: pdm-project/setup-pdm@v4
+        with:
+          python-version-file: pyproject.toml
+      - name: install dependencies
+        run: |
+          pdm install
+      - name: generate coverage report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pdm run coverage run --source=feeph.i2c -m pytest tests/
+          pdm run coveralls
+          mkdir -p coverage
+          pdm run coverage-lcov --output_file_path=coverage/lcov.info
+      - name: coveralls action
+        uses: coverallsapp/github-action@v2

--- a/.github/workflows/validate-code.yaml
+++ b/.github/workflows/validate-code.yaml
@@ -68,16 +68,6 @@ jobs:
           if [[ -n $CONTRIB_FILES ]] ; then
             pdm run mypy $CONTRIB_FILES
           fi
-      - name: generate coverage report
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pdm run coverage run --source=feeph.i2c -m pytest tests/
-          pdm run coveralls
-          mkdir -p coverage
-          pdm run coverage-lcov --output_file_path=coverage/lcov.info
-      - name: coveralls action
-        uses: coverallsapp/github-action@v2
   test:
     name: perform unit tests
     # wait on linting results; makes no sense to test if the code is broken


### PR DESCRIPTION
The coveralls GitHub Action needs to run on push and pull-request, but
it doesn't make sense to run the full test-suite on every push since
the code has already been testing during the pull-request.
-> split coverage report and testing into two separate GitHub Actions